### PR TITLE
게시글 등록 기능 추가

### DIFF
--- a/backend/simcheong2/build.gradle
+++ b/backend/simcheong2/build.gradle
@@ -35,6 +35,10 @@ dependencies {
 	// open-ai
 	implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
 
+	// s3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'javax.xml.bind:jaxb-api:2.3.0'
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -50,9 +54,6 @@ dependencies {
 
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
-
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
-	implementation 'javax.xml.bind:jaxb-api:2.3.0'
 }
 
 dependencyManagement {

--- a/backend/simcheong2/build.gradle
+++ b/backend/simcheong2/build.gradle
@@ -21,13 +21,19 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://repo.spring.io/milestone' }
+}
+
+ext {
+	set('springAiVersion', "1.0.0-M1")
 }
 
 dependencies {
 	// 스웨거
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
-	//
+	// open-ai
+	implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -47,6 +53,12 @@ dependencies {
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'javax.xml.bind:jaxb-api:2.3.0'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.ai:spring-ai-bom:${springAiVersion}"
+	}
 }
 
 tasks.named('test') {

--- a/backend/simcheong2/src/main/java/com/example/simcheong2/domain/image/entity/Image.java
+++ b/backend/simcheong2/src/main/java/com/example/simcheong2/domain/image/entity/Image.java
@@ -9,14 +9,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-
 @Entity
 @Getter
-@Builder(toBuilder = true)
 @NoArgsConstructor
 public class Image {
 
@@ -38,11 +35,13 @@ public class Image {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
-    public Image(Integer imageId, String fileUrl, String imageText, Integer imageIndex, Post post) {
-        this.imageId = imageId;
+    public Image(String fileUrl, String imageText, Integer imageIndex) {
         this.fileUrl = fileUrl;
         this.imageText = imageText;
         this.imageIndex = imageIndex;
+    }
+
+    public void updatePost(Post post) {
         this.post = post;
     }
 }

--- a/backend/simcheong2/src/main/java/com/example/simcheong2/domain/post/controller/PostController.java
+++ b/backend/simcheong2/src/main/java/com/example/simcheong2/domain/post/controller/PostController.java
@@ -6,8 +6,6 @@ import com.example.simcheong2.domain.post.service.PostCreateService;
 import com.example.simcheong2.domain.post.service.PostSearchService;
 import com.example.simcheong2.domain.user_post_like.controller.request.LikeRequest;
 import com.example.simcheong2.domain.user_post_like.service.LikeService;
-import com.example.simcheong2.global.ai.OpenAiHelper;
-import com.example.simcheong2.global.s3.S3Uploader;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -33,9 +31,6 @@ public class PostController {
     private final PostCreateService postCreateService;
     private final PostSearchService postSearchService;
 
-    private final OpenAiHelper openAiHelper;
-    private final S3Uploader s3Uploader;
-
     // 메인 피드
     @GetMapping("/main")
     public ResponseEntity<List<FeedResponse>> mainPosts() {
@@ -54,13 +49,8 @@ public class PostController {
             HttpServletRequest servletRequest,
             @RequestPart List<MultipartFile> images,
             @RequestPart @Valid PostContentRequest request) {
-        try {
-            String s3Url = s3Uploader.uploadFile(images.get(0), "static");
-            String uploadDirRealPath = servletRequest.getSession().getServletContext().getRealPath("/upload/"); // 저장 디렉토리 경로
-            String text = openAiHelper.getTextFromMultipartFile(images.get(0), uploadDirRealPath);
-        } catch (Exception e) {
-            return ResponseEntity.ok(false);
-        }
+        String uploadDirRealPath = servletRequest.getSession().getServletContext().getRealPath("/upload/"); // 저장 디렉토리 경로
+        postCreateService.createPost(1, images, request.getContent(), uploadDirRealPath);
         return ResponseEntity.ok(true);
     }
 

--- a/backend/simcheong2/src/main/java/com/example/simcheong2/domain/post/controller/PostController.java
+++ b/backend/simcheong2/src/main/java/com/example/simcheong2/domain/post/controller/PostController.java
@@ -7,6 +7,7 @@ import com.example.simcheong2.domain.post.service.PostSearchService;
 import com.example.simcheong2.domain.user_post_like.controller.request.LikeRequest;
 import com.example.simcheong2.domain.user_post_like.service.LikeService;
 import com.example.simcheong2.global.ai.OpenAiHelper;
+import com.example.simcheong2.global.s3.S3Uploader;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +34,7 @@ public class PostController {
     private final PostSearchService postSearchService;
 
     private final OpenAiHelper openAiHelper;
+    private final S3Uploader s3Uploader;
 
     // 메인 피드
     @GetMapping("/main")
@@ -52,8 +54,13 @@ public class PostController {
             HttpServletRequest servletRequest,
             @RequestPart List<MultipartFile> images,
             @RequestPart @Valid PostContentRequest request) {
-        String uploadDirRealPath = servletRequest.getSession().getServletContext().getRealPath("/upload/"); // 저장 디렉토리 경로
-        String text = openAiHelper.getTextFromMultipartFile(images.get(0), uploadDirRealPath);
+        try {
+            String s3Url = s3Uploader.uploadFile(images.get(0), "static");
+            String uploadDirRealPath = servletRequest.getSession().getServletContext().getRealPath("/upload/"); // 저장 디렉토리 경로
+            String text = openAiHelper.getTextFromMultipartFile(images.get(0), uploadDirRealPath);
+        } catch (Exception e) {
+            return ResponseEntity.ok(false);
+        }
         return ResponseEntity.ok(true);
     }
 

--- a/backend/simcheong2/src/main/java/com/example/simcheong2/domain/post/controller/PostController.java
+++ b/backend/simcheong2/src/main/java/com/example/simcheong2/domain/post/controller/PostController.java
@@ -6,7 +6,9 @@ import com.example.simcheong2.domain.post.service.PostCreateService;
 import com.example.simcheong2.domain.post.service.PostSearchService;
 import com.example.simcheong2.domain.user_post_like.controller.request.LikeRequest;
 import com.example.simcheong2.domain.user_post_like.service.LikeService;
+import com.example.simcheong2.global.ai.OpenAiHelper;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +32,8 @@ public class PostController {
     private final PostCreateService postCreateService;
     private final PostSearchService postSearchService;
 
+    private final OpenAiHelper openAiHelper;
+
     // 메인 피드
     @GetMapping("/main")
     public ResponseEntity<List<FeedResponse>> mainPosts() {
@@ -44,15 +48,18 @@ public class PostController {
 
     //게시글등록
     @PostMapping
-    public ResponseEntity<Boolean> createPost (
-            @RequestPart List < MultipartFile > images,
-            @RequestPart @Valid PostContentRequest request){
+    public ResponseEntity<Boolean> createPost(
+            HttpServletRequest servletRequest,
+            @RequestPart List<MultipartFile> images,
+            @RequestPart @Valid PostContentRequest request) {
+        String uploadDirRealPath = servletRequest.getSession().getServletContext().getRealPath("/upload/"); // 저장 디렉토리 경로
+        String text = openAiHelper.getTextFromMultipartFile(images.get(0), uploadDirRealPath);
         return ResponseEntity.ok(true);
     }
 
     // 게시글 좋아요
     @PostMapping("/like")
-    public ResponseEntity<Boolean> likePost(@RequestBody @Valid LikeRequest request){
+    public ResponseEntity<Boolean> likePost(@RequestBody @Valid LikeRequest request) {
         return ResponseEntity.ok(true);
     }
 }

--- a/backend/simcheong2/src/main/java/com/example/simcheong2/domain/post/entity/Post.java
+++ b/backend/simcheong2/src/main/java/com/example/simcheong2/domain/post/entity/Post.java
@@ -5,25 +5,17 @@ import com.example.simcheong2.domain.image.entity.Image;
 import com.example.simcheong2.domain.post_blame.entity.PostBlame;
 import com.example.simcheong2.domain.user.entity.User;
 import com.example.simcheong2.domain.user_post_like.entity.UserPostLike;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
+
+import java.util.List;
 import java.util.Set;
 
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 
 @Entity
 @Getter
-@Builder(toBuilder = true)
 @NoArgsConstructor
 public class Post {
 
@@ -42,8 +34,8 @@ public class Post {
     @OneToMany(mappedBy = "post")
     private Set<Comment> postComments;
 
-    @OneToMany(mappedBy = "post")
-    private Set<Image> postImages;
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Image> postImages;
 
     @OneToMany(mappedBy = "post")
     private Set<UserPostLike> postUserPostLikes;
@@ -51,13 +43,13 @@ public class Post {
     @OneToMany(mappedBy = "blamedPost")
     private Set<PostBlame> blamedPostPostBlames;
 
-    public Post(Integer postId, String content, User user, Set<Comment> postComments, Set<Image> postImages, Set<UserPostLike> postUserPostLikes, Set<PostBlame> blamedPostPostBlames) {
-        this.postId = postId;
+    public Post(String content, List<Image> postImages) {
         this.content = content;
-        this.user = user;
-        this.postComments = postComments;
         this.postImages = postImages;
-        this.postUserPostLikes = postUserPostLikes;
-        this.blamedPostPostBlames = blamedPostPostBlames;
+        postImages.forEach(image -> image.updatePost(this));
+    }
+
+    public void updateUser(User user) {
+        this.user = user;
     }
 }

--- a/backend/simcheong2/src/main/java/com/example/simcheong2/domain/post/entity/dto/ImageAnalysisResultDTO.java
+++ b/backend/simcheong2/src/main/java/com/example/simcheong2/domain/post/entity/dto/ImageAnalysisResultDTO.java
@@ -1,0 +1,15 @@
+package com.example.simcheong2.domain.post.entity.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+@ToString
+@Builder(toBuilder = true)
+public class ImageAnalysisResultDTO {
+    private String imageUrl;
+    private String analyzedText;
+
+}

--- a/backend/simcheong2/src/main/java/com/example/simcheong2/domain/post/service/PostCreateService.java
+++ b/backend/simcheong2/src/main/java/com/example/simcheong2/domain/post/service/PostCreateService.java
@@ -1,14 +1,77 @@
 package com.example.simcheong2.domain.post.service;
+
+import com.example.simcheong2.domain.image.entity.Image;
+import com.example.simcheong2.domain.post.entity.Post;
+import com.example.simcheong2.domain.post.entity.dto.ImageAnalysisResultDTO;
 import com.example.simcheong2.domain.post.repository.PostRepository;
+import com.example.simcheong2.domain.user.entity.User;
+import com.example.simcheong2.domain.user.repository.UserRepository;
+import com.example.simcheong2.global.ai.OpenAiHelper;
+import com.example.simcheong2.global.exception.model.CustomException;
+import com.example.simcheong2.global.exception.model.ErrorCode;
+import com.example.simcheong2.global.s3.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class PostCreateService {
+    private final UserRepository userRepository;
     private final PostRepository postRepository;
+    private final PostValidationService postValidationService;
+
+    private final OpenAiHelper openAiHelper;
+    private final S3Uploader s3Uploader;
+
+    public void createPost(int userId, List<MultipartFile> multipartFiles, String content, String uploadDirRealPath) {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "등록된 유저가 아닙니다"));
+        if (!postValidationService.isFileSizeWithinLimit(multipartFiles)) throw createImageSizeException();
+        List<ImageAnalysisResultDTO> imageAnalysisResultDTOS = uploadImages(multipartFiles, uploadDirRealPath);
+        createPost(user, imageAnalysisResultDTOS, content);
+    }
+
+    private void createPost(User user, List<ImageAnalysisResultDTO> imageAnalysisResultDTOS, String content) {
+        log.info("게시물 추가");
+        user.addPost(new Post(content, createImages(imageAnalysisResultDTOS, content)));
+    }
+
+    public static List<Image> createImages(List<ImageAnalysisResultDTO> imageAnalysisResultDTOS, String content) {
+        AtomicInteger index = new AtomicInteger();
+        return imageAnalysisResultDTOS.stream()
+                .map(dto -> new Image(dto.getImageUrl(), content, index.getAndIncrement()))
+                .collect(Collectors.toList());
+    }
+
+    private List<ImageAnalysisResultDTO> uploadImages(List<MultipartFile> multipartFiles, String uploadDirRealPath) {
+        return multipartFiles.stream()
+                .map(multipartFile -> uploadImage(multipartFile, uploadDirRealPath))
+                .collect(Collectors.toList());
+    }
+
+    private ImageAnalysisResultDTO uploadImage(MultipartFile multipartFile, String uploadDirRealPath) {
+        try {
+            String s3Url = s3Uploader.uploadFile(multipartFile, "static");
+            String text = openAiHelper.getTextFromMultipartFile(multipartFile, uploadDirRealPath);
+            return ImageAnalysisResultDTO.builder()
+                    .imageUrl(s3Url)
+                    .analyzedText(text)
+                    .build();
+        } catch (Exception e) {
+            throw createImageSizeException();
+        }
+    }
+
+    private CustomException createImageSizeException() {
+        return new CustomException(ErrorCode.BAD_REQUEST, "이미지 업로드 과정에서 문제가 생겼습니다. 이미지 크기가 너무 큰 것은 아닌지 다시 확인해주세요.");
+    }
 }

--- a/backend/simcheong2/src/main/java/com/example/simcheong2/domain/post/service/PostValidationService.java
+++ b/backend/simcheong2/src/main/java/com/example/simcheong2/domain/post/service/PostValidationService.java
@@ -1,0 +1,35 @@
+package com.example.simcheong2.domain.post.service;
+
+import com.example.simcheong2.domain.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PostValidationService {
+    private final PostRepository postRepository;
+
+    private static final long MAX_FILE_SIZE = 20 * 1024 * 1024; // 5MB
+
+    public boolean isFileSizeWithinLimit(MultipartFile file) {
+        long fileSize = file.getSize();
+        return fileSize <= MAX_FILE_SIZE;
+    }
+
+    public boolean isFileSizeWithinLimit(List<MultipartFile> files) {
+        for (MultipartFile file : files) {
+            long fileSize = file.getSize();
+            log.info("파일 크기: {}", fileSize);
+            if (fileSize > MAX_FILE_SIZE) return false;
+        }
+        return true;
+    }
+}

--- a/backend/simcheong2/src/main/java/com/example/simcheong2/domain/user/entity/User.java
+++ b/backend/simcheong2/src/main/java/com/example/simcheong2/domain/user/entity/User.java
@@ -7,14 +7,11 @@ import com.example.simcheong2.domain.user_blame.entity.UserBlame;
 import com.example.simcheong2.domain.user_post_like.entity.UserPostLike;
 import com.example.simcheong2.domain.follow.entity.Follow;
 import com.example.simcheong2.domain.post.entity.Post;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 import lombok.Builder;
@@ -66,8 +63,8 @@ public class User {
     @Column(columnDefinition = "tinyint", length = 1)
     private Boolean postVisible;
 
-    @OneToMany(mappedBy = "user")
-    private Set<Post> userPosts;
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Post> userPosts = new ArrayList<>();
 
     @OneToMany(mappedBy = "user")
     private Set<Comment> userComments;
@@ -93,7 +90,7 @@ public class User {
     @OneToMany(mappedBy = "blamer")
     private Set<PostBlame> blamerPostBlames;
 
-    public User(Integer userId, String email, String password, String phone, Boolean gender, OffsetDateTime birth, String name, String nickname, String introduce, String profileImage, Boolean disabled, Boolean postVisible, Set<Post> userPosts, Set<Comment> userComments, Set<UserPostLike> userUserPostLikes, Set<Follow> followerFollows, Set<Follow> followingFollows, Set<UserBlame> blamerUserBlames, Set<UserBlame> blamedUserUserBlames, Set<CommentBlame> blamerCommentBlames, Set<PostBlame> blamerPostBlames) {
+    public User(Integer userId, String email, String password, String phone, Boolean gender, OffsetDateTime birth, String name, String nickname, String introduce, String profileImage, Boolean disabled, Boolean postVisible, List<Post> userPosts, Set<Comment> userComments, Set<UserPostLike> userUserPostLikes, Set<Follow> followerFollows, Set<Follow> followingFollows, Set<UserBlame> blamerUserBlames, Set<UserBlame> blamedUserUserBlames, Set<CommentBlame> blamerCommentBlames, Set<PostBlame> blamerPostBlames) {
         this.userId = userId;
         this.email = email;
         this.password = password;
@@ -115,5 +112,10 @@ public class User {
         this.blamedUserUserBlames = blamedUserUserBlames;
         this.blamerCommentBlames = blamerCommentBlames;
         this.blamerPostBlames = blamerPostBlames;
+    }
+
+    public void addPost(Post post) {
+        this.userPosts.add(post);
+        post.updateUser(this);
     }
 }

--- a/backend/simcheong2/src/main/java/com/example/simcheong2/domain/user/repository/UserRepository.java
+++ b/backend/simcheong2/src/main/java/com/example/simcheong2/domain/user/repository/UserRepository.java
@@ -3,6 +3,9 @@ package com.example.simcheong2.domain.user.repository;
 import com.example.simcheong2.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 
 public interface UserRepository extends JpaRepository<User, Integer> {
+    Optional<User> findByUserId(int userId);
 }

--- a/backend/simcheong2/src/main/java/com/example/simcheong2/global/ai/OpenAiConfig.java
+++ b/backend/simcheong2/src/main/java/com/example/simcheong2/global/ai/OpenAiConfig.java
@@ -6,9 +6,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class OpenAiConfig {
-    private final String defaultMessage = "한국어로 답변 해줘. " +
-            "단, 이 사진이 너무 성적으로 야하거나 인종차별적이나 장애차별적인 성격을 띄고 있다면 " +
-            "'잘 모르겠어요'라는 텍스트로 응답해줘";
+    public String defaultMessage = "친절한 어투로 한국어로 답변 해줘.";
 
     @Bean
     ChatClient chatClient(ChatClient.Builder builder) {

--- a/backend/simcheong2/src/main/java/com/example/simcheong2/global/ai/OpenAiConfig.java
+++ b/backend/simcheong2/src/main/java/com/example/simcheong2/global/ai/OpenAiConfig.java
@@ -1,0 +1,18 @@
+package com.example.simcheong2.global.ai;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenAiConfig {
+    private final String defaultMessage = "한국어로 답변 해줘. " +
+            "단, 이 사진이 너무 성적으로 야하거나 인종차별적이나 장애차별적인 성격을 띄고 있다면 " +
+            "'잘 모르겠어요'라는 텍스트로 응답해줘";
+
+    @Bean
+    ChatClient chatClient(ChatClient.Builder builder) {
+        return builder.defaultSystem(defaultMessage)
+                .build();
+    }
+}

--- a/backend/simcheong2/src/main/java/com/example/simcheong2/global/ai/OpenAiHelper.java
+++ b/backend/simcheong2/src/main/java/com/example/simcheong2/global/ai/OpenAiHelper.java
@@ -24,6 +24,9 @@ public class OpenAiHelper {
     private final ChatClient chatClient;
     private final FileHelper fileHelper;
 
+    private String requestText = "What’s in this image? 한국어로 해줘. " +
+            "단, 이 사진이 너무 야하거나 인종차별이나 장애차별적인 성격을 띄고 있다면 '부적절한 컨텐츠입니다.'라는 텍스트를 응답해줘";
+
     public String getTextFromMultipartFile(MultipartFile multipartFile, String uploadDirRealPath) {
         String uploadFileName = fileHelper.saveFile(multipartFile, uploadDirRealPath);
         if (uploadFileName == null) {
@@ -47,9 +50,7 @@ public class OpenAiHelper {
         log.info("이미지 분석 시작! 경로: {}", imageFullPath);
 
         Resource imageData = new FileSystemResource(imageFullPath);
-        UserMessage userMessage = new UserMessage("What’s in this image? 한국어로 답변 해줘",
-                new Media(MimeTypeUtils.IMAGE_JPEG, imageData));
-
+        UserMessage userMessage = new UserMessage(requestText, new Media(MimeTypeUtils.IMAGE_JPEG, imageData));
         return chatClient.prompt(new Prompt(userMessage)).call().content();
     }
 

--- a/backend/simcheong2/src/main/java/com/example/simcheong2/global/ai/OpenAiHelper.java
+++ b/backend/simcheong2/src/main/java/com/example/simcheong2/global/ai/OpenAiHelper.java
@@ -1,0 +1,43 @@
+package com.example.simcheong2.global.ai;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.Media;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MimeTypeUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+
+@Component
+@RequiredArgsConstructor
+public class OpenAiHelper {
+    private final ChatClient chatClient;
+
+    public String getTextFromMultipartFile(String realPath, MultipartFile multipartFile) {
+        System.out.println("이미지 저장 시작");
+//        String imagePath = saveFile(multipartFile, realPath);
+        String imagePath = "";
+
+        System.out.println("----");
+        System.out.println(realPath);
+        System.out.println(imagePath);
+
+        System.out.println("이미지 분석 시작");
+        String imageFullPath = realPath + File.separator + imagePath;
+
+        Resource imageData = new FileSystemResource(imageFullPath);
+        UserMessage userMessage = new UserMessage("What’s in this image? 한국어로 답변 해줘",
+                new Media(MimeTypeUtils.IMAGE_JPEG, imageData));
+
+        String responseText = chatClient.prompt(new Prompt(userMessage)).call().content();
+
+        // 저장된 이미지 파일 삭제
+
+        return responseText;
+    }
+}

--- a/backend/simcheong2/src/main/java/com/example/simcheong2/global/file/FileHelper.java
+++ b/backend/simcheong2/src/main/java/com/example/simcheong2/global/file/FileHelper.java
@@ -1,0 +1,68 @@
+package com.example.simcheong2.global.file;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.util.UUID;
+
+
+@Component
+@Slf4j
+public class FileHelper {
+    // 파일을 삭제하는 메소드
+    public void deleteFile(String uploadDirRealPath, String serverUploadFileName) {
+        log.info("파일 삭제: {}", serverUploadFileName);
+        File fileToDelete = new File(getFullPath(uploadDirRealPath, serverUploadFileName));
+        if (fileToDelete.delete()) {
+            log.info("파일 삭제 성공: {}", serverUploadFileName);
+            return;
+        }
+        log.info("파일 삭제 실패: {}", serverUploadFileName);
+    }
+
+    // 파일을 저장하는 메소드
+    public String saveFile(MultipartFile file, String uploadDirRealPath) {
+        try {
+            String serverUploadFileName = serverUploadFile(file, uploadDirRealPath);
+            log.info("uploadFileName name: {}", serverUploadFileName);
+            return serverUploadFileName;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /*
+     * return 업로드된 파일 네임.
+     */
+    public String serverUploadFile(MultipartFile multipartFile, String uploadDirRealPath) {
+        if (multipartFile.isEmpty()) return null;
+        String originalFilename = multipartFile.getOriginalFilename(); //원래 파일명
+        String serverUploadFileName = createServerFileName(originalFilename); //uuid 생성해서 뒤에 원래파일명의 확장자명 붙이기
+        log.info("upload 된 파일 이름: {}", serverUploadFileName);
+        try {
+            multipartFile.transferTo(new File(getFullPath(uploadDirRealPath, serverUploadFileName)));//저장: (서버에 업로드되는 파일명, 업로드 되는 경로)
+            return serverUploadFileName;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public String getFullPath(String fileDir, String filename) {
+        return fileDir + filename;
+    }
+
+    private String createServerFileName(String originalFilename) {
+        String uuid = UUID.randomUUID().toString();
+        String ext = extractExt(originalFilename);
+        log.info("파일 확장자: {}", ext);
+        return uuid + "." + ext;
+    }
+
+    //원래 파일명에서 확장자 뽑기(.jpg, .png ...)
+    private String extractExt(String originalFilename) {
+        int pos = originalFilename.lastIndexOf(".");
+        return originalFilename.substring(pos + 1);
+    }
+}

--- a/backend/simcheong2/src/main/java/com/example/simcheong2/global/s3/S3Config.java
+++ b/backend/simcheong2/src/main/java/com/example/simcheong2/global/s3/S3Config.java
@@ -1,0 +1,28 @@
+package com.example.simcheong2.global.s3;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey,secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                    .withRegion(region)
+                    .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+                    .build();
+    }
+}

--- a/backend/simcheong2/src/main/java/com/example/simcheong2/global/s3/S3Uploader.java
+++ b/backend/simcheong2/src/main/java/com/example/simcheong2/global/s3/S3Uploader.java
@@ -1,0 +1,67 @@
+package com.example.simcheong2.global.s3;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.example.simcheong2.global.file.FileHelper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3Uploader {
+    private final FileHelper fileHelper;
+    private final AmazonS3Client amazonS3Client;
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadFile(MultipartFile multipartFile, String dirName) throws IOException {
+        File uploadFile = convert(multipartFile)  // 파일 변환할 수 없으면 에러
+                .orElseThrow(() -> new IllegalArgumentException("error: MultipartFile -> File convert fail"));
+        return upload(uploadFile, dirName);
+    }
+
+    private String upload(File uploadFile, String filePath) {
+        String fileName = filePath + "/" + UUID.randomUUID() + uploadFile.getName();   // S3에 저장된 파일 이름
+        String uploadImageUrl = putS3(uploadFile, fileName); // s3로 업로드
+        removeNewFile(uploadFile);
+        return uploadImageUrl;
+    }
+
+    // S3로 업로드
+    private String putS3(File uploadFile, String fileName) {
+        amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile).withCannedAcl(CannedAccessControlList.PublicRead));
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    // 로컬에 저장된 이미지 지우기
+    private void removeNewFile(File targetFile) {
+        if (targetFile.delete()) {
+            System.out.println("파일 삭제 성공");
+            return;
+        }
+        log.info("파일 삭제 실패");
+    }
+
+    // 로컬에 파일 업로드 하기
+    private Optional<File> convert(MultipartFile file) throws IOException {
+        File convertFile = new File(file.getOriginalFilename()); // 업로드한 파일의 이름
+        if (convertFile.createNewFile()) { // 바로 위에서 지정한 경로에 File이 생성됨 (경로가 잘못되었다면 생성 불가능)
+            try (FileOutputStream fos = new FileOutputStream(convertFile)) { // FileOutputStream 데이터를 파일에 바이트 스트림으로 저장하기 위함
+                fos.write(file.getBytes());
+            }
+            return Optional.of(convertFile);
+        }
+        return Optional.empty();
+    }
+}

--- a/backend/simcheong2/src/main/java/com/example/simcheong2/global/s3/S3Uploader.java
+++ b/backend/simcheong2/src/main/java/com/example/simcheong2/global/s3/S3Uploader.java
@@ -35,6 +35,7 @@ public class S3Uploader {
         String fileName = filePath + "/" + UUID.randomUUID() + uploadFile.getName();   // S3에 저장된 파일 이름
         String uploadImageUrl = putS3(uploadFile, fileName); // s3로 업로드
         removeNewFile(uploadFile);
+        log.info("S3 업로드 URL: {}", uploadImageUrl);
         return uploadImageUrl;
     }
 


### PR DESCRIPTION
현재 유저 회원가입 기능이 없어서, 임의로 1번 유저를 로컬에서 직접 만들고, 1번 유저를 불러와서 사용하도록 했습니다.

추가 내용은 다음과 같습니다.
1. OpenAI 연동해서 이미지 파일 서버에 임시 저장후 분석 텍스트 얻고 파일 삭제
2. S3에 이미지 업로드해서 url 얻기
3. 요청받은 이미지들과 게시글텍스트(content)를 토대로, (Image엔티티 객체 만들고 -> Post엔티티 객체 만들고 -> User엔티티에 추가)

현재 문제점
1. 현재 파일 업로드 부분에 대한 역할이 분리가 잘 안되어있습니다. 하지만, 저희 마감기한을 생각했을 때 일단 머지하고 다음에 수정했으면 좋겠습니다.
2. 엔티티 클래스를 저희가 sql 스키마 파일로부터 자동으로 만들었더니 설정들이 좀 빠진 부분이 있었습니다. (Cascade, orphanRemoval 등) 이 부분들을 수정해야 할 것 같습니다. 